### PR TITLE
Handle empty offspring and fix funeral safety

### DIFF
--- a/R/branching_process_main.R
+++ b/R/branching_process_main.R
@@ -292,6 +292,7 @@ branching_process_main <- function(
                                                        onset_to_recovery = onset_to_recovery)
       tdf$n_offspring[idx] <- nrow(complete_offspring_df)
     } else {
+      complete_offspring_df <- tdf[0, , drop = FALSE]
       tdf$n_offspring[idx] <- 0
     }
     tdf$offspring_generated[idx] <- TRUE

--- a/R/complete_offspring_info.R
+++ b/R/complete_offspring_info.R
@@ -123,11 +123,27 @@ complete_offspring_info <- function(
   comm_and_death_and_hcw <- offspring_outcome & !offspring_actually_hosp & offspring_dataframe$class == "HCW"       ## those hcw who die and who do so in the community
   comm_and_death_and_genPop <- offspring_outcome & !offspring_actually_hosp & offspring_dataframe$class == "genPop" ## those genPop who die and who do so in the community
 
-  offspring_funeral_safety <- rep(FALSE, num_offspring)
-  offspring_funeral_safety[hosp_and_death_and_hcw] <- rbinom(n = sum(hosp_and_death_and_hcw), size = 1, prob = p_unsafe_funeral_hosp_hcw)
-  offspring_funeral_safety[hosp_and_death_and_genPop] <- rbinom(n = sum(hosp_and_death_and_genPop), size = 1, prob = p_unsafe_funeral_hosp_genPop)
-  offspring_funeral_safety[comm_and_death_and_hcw] <- rbinom(n = sum(comm_and_death_and_hcw), size = 1, prob = p_unsafe_funeral_comm_hcw)
-  offspring_funeral_safety[comm_and_death_and_genPop] <- rbinom(n = sum(comm_and_death_and_genPop), size = 1, prob = p_unsafe_funeral_comm_genPop)
+  offspring_funeral_safety <- rep(NA_character_, num_offspring)
+  offspring_funeral_safety[hosp_and_death_and_hcw] <- ifelse(
+    rbinom(n = sum(hosp_and_death_and_hcw), size = 1, prob = p_unsafe_funeral_hosp_hcw) == 1,
+    "unsafe",
+    "safe"
+  )
+  offspring_funeral_safety[hosp_and_death_and_genPop] <- ifelse(
+    rbinom(n = sum(hosp_and_death_and_genPop), size = 1, prob = p_unsafe_funeral_hosp_genPop) == 1,
+    "unsafe",
+    "safe"
+  )
+  offspring_funeral_safety[comm_and_death_and_hcw] <- ifelse(
+    rbinom(n = sum(comm_and_death_and_hcw), size = 1, prob = p_unsafe_funeral_comm_hcw) == 1,
+    "unsafe",
+    "safe"
+  )
+  offspring_funeral_safety[comm_and_death_and_genPop] <- ifelse(
+    rbinom(n = sum(comm_and_death_and_genPop), size = 1, prob = p_unsafe_funeral_comm_genPop) == 1,
+    "unsafe",
+    "safe"
+  )
 
   ################################################################################################################################
   ## Step 5: Update and output offspring dataframe


### PR DESCRIPTION
## Summary
- initialize an empty offspring dataframe so parents with no offspring are handled safely
- ensure funeral safety is recorded only for deaths and stored as safe/unsafe strings

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ccde601c4832bb5ca2a2c0fe83992)