### PR TITLE
Fix sample() single-value gotcha causing hcw_available to go negative

### DIFF
--- a/R/offspring_function_funeral.R
+++ b/R/offspring_function_funeral.R
@@ -199,8 +199,10 @@ offspring_function_funeral <- function(
   n_hcw_generated <- length(hcw_idx)
   if (n_hcw_generated > hcw_available) {
     # Randomly select which HCWs to convert back to genPop
+    # Note: use sample.int() with indexing to avoid R's sample() single-value gotcha
+    # where sample(n, size=k) samples from 1:n instead of c(n) when length(n)==1
     n_excess <- n_hcw_generated - hcw_available
-    convert_idx <- sample(hcw_idx, size = n_excess)
+    convert_idx <- hcw_idx[sample.int(n_hcw_generated, size = n_excess)]
     offspring_class[convert_idx] <- "genPop"
   }
 

--- a/R/offspring_function_genPop.R
+++ b/R/offspring_function_genPop.R
@@ -121,8 +121,10 @@ offspring_function_genPop <- function(
   n_hcw_generated <- length(hcw_idx)
   if (n_hcw_generated > hcw_available) {
     # Randomly select which HCWs to convert back to genPop
+    # Note: use sample.int() with indexing to avoid R's sample() single-value gotcha
+    # where sample(n, size=k) samples from 1:n instead of c(n) when length(n)==1
     n_excess <- n_hcw_generated - hcw_available
-    convert_idx <- sample(hcw_idx, size = n_excess)
+    convert_idx <- hcw_idx[sample.int(n_hcw_generated, size = n_excess)]
     offspring_class[convert_idx] <- "genPop"
   }
 

--- a/R/offspring_function_hcw.R
+++ b/R/offspring_function_hcw.R
@@ -149,8 +149,10 @@ offspring_function_hcw <- function(
   n_hcw_generated <- length(hcw_idx)
   if (n_hcw_generated > hcw_available) {
     # Randomly select which HCWs to convert back to genPop
+    # Note: use sample.int() with indexing to avoid R's sample() single-value gotcha
+    # where sample(n, size=k) samples from 1:n instead of c(n) when length(n)==1
     n_excess <- n_hcw_generated - hcw_available
-    convert_idx <- sample(hcw_idx, size = n_excess)
+    convert_idx <- hcw_idx[sample.int(n_hcw_generated, size = n_excess)]
     offspring_class[convert_idx] <- "genPop"
   }
 


### PR DESCRIPTION
When exactly 1 HCW is generated and needs to be converted back to genPop, R's sample(n, size=k) interprets a single integer n as "sample from 1:n" rather than "sample from c(n)". This causes the wrong index to be converted, leaving the HCW count unchanged while hcw_available is decremented, eventually causing hcw_available to become negative and triggering validation errors.

The fix uses sample.int() with indexing: hcw_idx[sample.int(length, size)] which correctly handles the single-element case.

https://claude.ai/code/session_01EKb2DLKJUBRsDNpyR3KsDW