### PR TITLE
Update Claude Code workflows to use Opus 4.6

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,5 +41,5 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--model claude-opus-4-5-20251101'
+          claude_args: '--model claude-opus-4-6'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,5 +46,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--model claude-opus-4-5-20251101'
+          claude_args: '--model claude-opus-4-6'
 


### PR DESCRIPTION
Switch model from claude-opus-4-5-20251101 to claude-opus-4-6 in both claude-code-review.yml and claude.yml GitHub Actions workflows.

https://claude.ai/code/session_01CdaZQz2Z6JYY7Hrfjc6BEM