### PR TITLE
Implement setting-aware HCW depletion and clarify hcw_per_capita sema…

### DIFF
--- a/R/branching_process_main.R
+++ b/R/branching_process_main.R
@@ -72,7 +72,7 @@ branching_process_main <- function(
   ## Misc
   tf = Inf,
   population,
-  hcw_per_capita = 0.05,
+  hcw_per_capita = 0.05,  # HCWs per capita (per person); e.g. 0.05 = 50 HCWs per 1000 population
   check_final_size,
   initial_immune = 0,
   seeding_cases,
@@ -92,6 +92,7 @@ branching_process_main <- function(
   susc <- population - initial_immune
 
   ## Initialise the HCW population
+  ## hcw_per_capita is the number of HCWs per person (e.g. 0.05 = 5 HCWs per 100 people)
   hcw_total <- round(hcw_per_capita * population)
   if (hcw_total <= 0) {
     warning("hcw_per_capita * population rounds to 0 HCWs (hcw_per_capita = ",

--- a/R/offspring_function_funeral.R
+++ b/R/offspring_function_funeral.R
@@ -194,11 +194,13 @@ offspring_function_funeral <- function(
     stop("Step 6 of funeral offspring function is broken")
   }
 
-  # Step 7: Cap HCW infections based on hcw_available - if more HCWs were generated than are available, randomly convert excess back to genPop
+  # Step 7: Cap HCW infections based on hcw_available.
+  # Setting-aware depletion logic: funeral is a non-hospital setting, so excess
+  # HCW infections are CONVERTED to genPop (not dropped). This represents the
+  # assumption that informal carers replace HCWs in community/funeral contexts.
   hcw_idx <- which(offspring_class == "HCW")
   n_hcw_generated <- length(hcw_idx)
   if (n_hcw_generated > hcw_available) {
-    # Randomly select which HCWs to convert back to genPop
     # Note: use sample.int() with indexing to avoid R's sample() single-value gotcha
     # where sample(n, size=k) samples from 1:n instead of c(n) when length(n)==1
     n_excess <- n_hcw_generated - hcw_available

--- a/R/offspring_function_hcw.R
+++ b/R/offspring_function_hcw.R
@@ -144,16 +144,47 @@ offspring_function_hcw <- function(
   flip_hcw <- as.logical(rbinom(n = num_offspring_quarantine, size = 1, prob = prob_hcw))
   offspring_class[flip_hcw] <- "HCW"
 
-  # Step 6: Cap HCW infections based on hcw_available - if more HCWs were generated than are available, randomly convert excess back to genPop
+  # Step 6: Cap HCW infections based on hcw_available.
+  # Setting-aware depletion logic:
+  #   - Hospital-setting HCW infections are DROPPED (removed) when no HCWs are available,
+  #     because nosocomial transmission requires HCWs to be present and working.
+  #   - Community-setting HCW infections are CONVERTED to genPop when no HCWs are available,
+  #     representing the assumption that informal carers replace HCWs in the community.
   hcw_idx <- which(offspring_class == "HCW")
   n_hcw_generated <- length(hcw_idx)
   if (n_hcw_generated > hcw_available) {
-    # Randomly select which HCWs to convert back to genPop
-    # Note: use sample.int() with indexing to avoid R's sample() single-value gotcha
-    # where sample(n, size=k) samples from 1:n instead of c(n) when length(n)==1
     n_excess <- n_hcw_generated - hcw_available
-    convert_idx <- hcw_idx[sample.int(n_hcw_generated, size = n_excess)]
-    offspring_class[convert_idx] <- "genPop"
+
+    # Separate excess HCWs by setting: hospital vs community
+    hcw_settings <- infection_settings[hcw_idx]
+    hospital_hcw_idx <- hcw_idx[hcw_settings == "hospital"]
+    community_hcw_idx <- hcw_idx[hcw_settings == "community"]
+
+    # Priority: drop hospital HCW infections first (they can't happen without HCWs present)
+    n_hospital_to_drop <- min(length(hospital_hcw_idx), n_excess)
+    if (n_hospital_to_drop > 0) {
+      # Note: use sample.int() with indexing to avoid R's sample() single-value gotcha
+      # where sample(n, size=k) samples from 1:n instead of c(n) when length(n)==1
+      drop_idx <- hospital_hcw_idx[sample.int(length(hospital_hcw_idx), size = n_hospital_to_drop)]
+    } else {
+      drop_idx <- integer(0)
+    }
+
+    # Convert remaining excess from community HCWs to genPop
+    n_community_to_convert <- n_excess - n_hospital_to_drop
+    if (n_community_to_convert > 0) {
+      convert_idx <- community_hcw_idx[sample.int(length(community_hcw_idx), size = n_community_to_convert)]
+      offspring_class[convert_idx] <- "genPop"
+    }
+
+    # Build keep mask: drop the hospital HCW infections that exceed capacity
+    keep_mask <- rep(TRUE, length(offspring_class))
+    if (length(drop_idx) > 0) {
+      keep_mask[drop_idx] <- FALSE
+    }
+    infection_times <- infection_times[keep_mask]
+    infection_settings <- infection_settings[keep_mask]
+    offspring_class <- offspring_class[keep_mask]
   }
 
   # Step 7: Define and output dataframe with the results


### PR DESCRIPTION
…ntics

Setting-aware HCW depletion (per Dec 15 agreement):
- Hospital-setting HCW infections are DROPPED when hcw_available is exceeded, because nosocomial transmission requires HCWs to be present and working.
- Community/funeral-setting HCW infections are CONVERTED to genPop, representing informal carers replacing HCWs in non-hospital contexts.

Previously, all settings uniformly converted excess HCWs to genPop.

Also clarifies hcw_per_capita as HCWs per person (e.g. 0.05 = 50 per 1000).