### PR TITLE
Upgrade GitHub Actions permissions to enable write access

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
Updated GitHub Actions workflow permissions to grant write access for pull requests and issues, enabling Claude to perform write operations in addition to read-only access.

## Changes Made
- **claude-code-review.yml**: Upgraded `pull-requests` permission from `read` to `write`
- **claude.yml**: Upgraded all content-related permissions from `read` to `write`:
  - `contents: read` → `contents: write`
  - `pull-requests: read` → `pull-requests: write`
  - `issues: read` → `issues: write`

## Rationale
These permission changes enable the Claude workflows to:
- Create and update pull request comments and reviews
- Create and update issue comments
- Modify repository contents when needed

This is necessary for Claude to provide more interactive feedback and make automated changes as part of the code review and issue handling workflows.

https://claude.ai/code/session_01YZmY3PtjY5FqFxL6wqqJRu