### PR TITLE
Remove non-functional `tf` parameter from branching_process_main

### DIFF
--- a/R/branching_process_main.R
+++ b/R/branching_process_main.R
@@ -75,7 +75,6 @@ branching_process_main <- function(
   prob_hcw_cond_funeral_genPop = NULL, ## DESCRIPTION NEEDED HERE
 
   ## Misc
-  tf = Inf,
   population,
   hcw_per_capita = 10,
   check_final_size,
@@ -143,7 +142,7 @@ branching_process_main <- function(
   ###
   ### Sample each probability parameter on a grid built from the
   ### make_time_varying breakpoints (where supplied) plus midpoints, or
-  ### a default 0..tf grid otherwise. This catches curves that resolve
+  ### a default 0..365 grid otherwise. This catches curves that resolve
   ### outside [0, 1] somewhere in the simulation horizon before the
   ### simulation starts, rather than mid-run with a cryptic error.
   ###
@@ -164,7 +163,7 @@ branching_process_main <- function(
     prop_etu                      = prop_etu,
     ipc_helper                    = ipc_helper
   )
-  sanity_grid <- build_sanity_grid(sanity_params, tf = tf)
+  sanity_grid <- build_sanity_grid(sanity_params)
 
   for (nm in names(sanity_params)) {
     check_probability_on_grid(sanity_params[[nm]], sanity_grid, nm)

--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -14,9 +14,9 @@ rtrunc_gamma <- function(n, lower = -Inf, upper = Inf, Tg_shape, Tg_rate) {
 ## Build a sampling grid for the upfront sanity check on time-varying
 ## probability parameters. For any inputs that came from make_time_varying(),
 ## we include the breakpoints (and midpoints) so the grid covers every
-## changepoint. Falls back to an evenly spaced grid on [0, tf] (or 0–365 if
-## tf is infinite) when no time-varying inputs are supplied.
-build_sanity_grid <- function(params, tf = NULL) {
+## changepoint. Falls back to an evenly spaced 0–365 grid when no
+## time-varying inputs are supplied.
+build_sanity_grid <- function(params) {
   breakpoints <- numeric(0)
   for (p in params) {
     if (inherits(p, "time_varying_fn")) {
@@ -40,8 +40,7 @@ build_sanity_grid <- function(params, tf = NULL) {
     bp <- breakpoints[1]
     sort(unique(c(0, bp - 1, bp, bp + 1, max(bp + 10, 100))))
   } else {
-    upper <- if (!is.null(tf) && is.finite(tf)) tf else 365
-    seq(0, upper, length.out = 50)
+    seq(0, 365, length.out = 50)
   }
 }
 


### PR DESCRIPTION
## Summary

Removes the `tf` parameter from `branching_process_main` as flagged during the final review of #45. `tf` was documented as a "final time" but was never used to terminate the simulation loop — the only consumer was the upfront sanity check's grid-builder fallback, which now uses `seq(0, 365, length.out = 50)` directly when no time-varying parameter breakpoints are available.

## What changed

- `R/branching_process_main.R` — `tf = Inf` removed from the signature; `build_sanity_grid(sanity_params, tf = tf)` becomes `build_sanity_grid(sanity_params)`; the inline comment about the fallback is updated.
- `R/helper_functions.R` — `build_sanity_grid` loses its `tf` argument and the conditional fallback; the `else` branch is now a one-liner `seq(0, 365, length.out = 50)`.

## Breaking change

Any user code passing `tf = ...` to `branching_process_main` will now error with "unused argument". Given the parameter never did anything, this is a documented behaviour fix rather than a functionality loss.

## Tests

No test file references `tf` (verified with `grep`), so the existing test suite is unaffected.

If a time-based termination is needed later (e.g. "stop the simulation at day 365"), it can be re-introduced as a real condition in the main loop with a clearer name.

https://claude.ai/code/session_01YHPJ86kPES7dP6MYBESd5J

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHPJ86kPES7dP6MYBESd5J)_