### PR TITLE
Add time-varying transmissibility (mn_offspring_*)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,12 @@ Each infected person generates offspring based on their class:
 
 All use Negative Binomial distribution for offspring count and truncated Gamma for infection timing.
 
+The NB mean (`mn_offspring_genPop`, `mn_offspring_hcw`, `mn_offspring_funeral`) may be a scalar or a
+time-varying `function(t)` of absolute calendar time (e.g. via `make_time_varying()`). It is resolved
+to a single value per parent immediately before the NB draw: genPop/HCW at the **parent's infection
+time**, funeral at the **parent's death (outcome) time** (since the funeral occurs then). A constant
+function reproduces the equivalent scalar run bit-for-bit under a fixed seed (no extra RNG draws).
+
 ### Key Support Functions
 
 - **`complete_offspring_info()`** (`R/complete_offspring_info.R`) - Fills in offspring details: symptomatic status, hospitalization, death/recovery outcomes, delay times
@@ -93,9 +99,11 @@ Cases are tracked by where infection occurred: `community`, `hospital`, or `fune
 Uses testthat (edition 3). Test files go in `tests/testthat/`. Current suites:
 - `test-make_time_varying.R`
 - `test-time_varying_hospitalisation.R`
+- `test-time_varying_transmissibility.R`
 - `test-ppe_thinning.R`
 - `test-conditional_cfr.R`
 - `test-obv_pep.R`
+- `test-compute_reproduction_number.R`
 
 ## Notes
 

--- a/R/branching_process_main.R
+++ b/R/branching_process_main.R
@@ -20,8 +20,8 @@
 #' Iteratively generates offspring (community, hospital, and funeral
 #' transmission) from active cases until the outbreak ends or the configured
 #' final-size cap is reached. Time-varying scenario inputs (probabilities,
-#' delay factors, IPC / ETU coverage) can be passed as scalars or functions
-#' of time produced by [make_time_varying()].
+#' delay factors, IPC / ETU coverage, and mean-offspring transmissibility) can
+#' be passed as scalars or functions of time produced by [make_time_varying()].
 #'
 #' Per-argument documentation is pending; see the inline comments in
 #' `R/branching_process_main.R` for the current notes on each parameter.
@@ -33,15 +33,15 @@
 branching_process_main <- function(
 
   ## Transmission
-  mn_offspring_genPop = NULL,               # mean of the offspring distribution for genPop
+  mn_offspring_genPop = NULL,               # scalar or function(t): mean offspring distribution for genPop (resolved at parent infection time)
   overdisp_offspring_genPop = NULL,         # overdispersion of the offspring distribution for genPop
   Tg_shape_genPop = NULL,                   # gamma shape parameter for Tg distribution for general population
   Tg_rate_genPop = NULL,                    # gamma rate parameter for Tg distribution for general population
-  mn_offspring_hcw = NULL,                  # mean of the offspring distribution for HCWs
+  mn_offspring_hcw = NULL,                  # scalar or function(t): mean offspring distribution for HCWs (resolved at parent infection time)
   overdisp_offspring_hcw = NULL,            # overdispersion of the offspring distribution for HCWs
   Tg_shape_hcw = NULL,                      # gamma shape parameter for Tg distribution for HCWs
   Tg_rate_hcw = NULL,                       # gamma rate parameter for Tg distribution for HCWs
-  mn_offspring_funeral = NULL,              # mean number of offspring at unsafe funeral
+  mn_offspring_funeral = NULL,              # scalar or function(t): mean offspring at unsafe funeral (resolved at parent death time)
   overdisp_offspring_funeral = NULL,        # overdispersion of the above number of offspring
   Tg_shape_funeral = NULL,                  # gamma shape parameter for Tg distribution at funerals ### have high shape, high rate to get low variance ##
   Tg_rate_funeral = NULL,                   # gamma rate parameter for Tg distribution at funerals
@@ -223,7 +223,21 @@ branching_process_main <- function(
     obv_pep_coverage          = obv_pep_coverage,
     obv_pep_adherence             = obv_pep_adherence
   )
-  sanity_grid <- build_sanity_grid(sanity_params)
+  ## Build the sampling grid from ALL time-varying inputs -- the probabilities
+  ## above plus the positive-valued curves below -- so the upfront check lands on
+  ## every changepoint, including those of hospitalisation_delay_factor,
+  ## obv_pep_dpc, and the time-varying mean-offspring parameters.
+  grid_inputs <- c(
+    sanity_params,
+    list(
+      hospitalisation_delay_factor = hospitalisation_delay_factor,
+      obv_pep_dpc                  = obv_pep_dpc,
+      mn_offspring_genPop          = mn_offspring_genPop,
+      mn_offspring_hcw             = mn_offspring_hcw,
+      mn_offspring_funeral         = mn_offspring_funeral
+    )
+  )
+  sanity_grid <- build_sanity_grid(grid_inputs)
 
   for (nm in names(sanity_params)) {
     check_probability_on_grid(sanity_params[[nm]], sanity_grid, nm)
@@ -232,6 +246,14 @@ branching_process_main <- function(
   ## hospitalisation_delay_factor is strictly positive (a multiplier), not a probability.
   check_positive_on_grid(hospitalisation_delay_factor, sanity_grid,
                          "hospitalisation_delay_factor")
+
+  ## mn_offspring_* are strictly positive NB means and may be scalars or functions
+  ## of absolute calendar time. They are resolved inside the offspring functions
+  ## (genPop/HCW at the parent's infection time, funeral at the parent's death
+  ## time); here we only sanity-check positivity across the simulation horizon.
+  check_positive_on_grid(mn_offspring_genPop,  sanity_grid, "mn_offspring_genPop")
+  check_positive_on_grid(mn_offspring_hcw,     sanity_grid, "mn_offspring_hcw")
+  check_positive_on_grid(mn_offspring_funeral, sanity_grid, "mn_offspring_funeral")
 
   ## obv_pep_dpc is non-negative (0 = same-day treatment is a meaningful boundary value).
   check_nonneg_on_grid(obv_pep_dpc, sanity_grid, "obv_pep_dpc")

--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -81,6 +81,20 @@ check_positive_on_grid <- function(param, grid, param_name) {
   invisible(NULL)
 }
 
+## Resolve a strictly-positive parameter (scalar or function(t)) at the supplied
+## time(s), asserting every resolved value is finite and > 0. Used for
+## transmissibility-style parameters (e.g. the mn_offspring_* means) that may be
+## supplied either as a single positive scalar or as a function of absolute
+## calendar time. The interpolation itself is delegated to resolve_time_varying()
+## so callers stay scenario-agnostic.
+resolve_positive_time_varying <- function(param, t, param_name = "parameter") {
+  value <- resolve_time_varying(param = param, t = t, param_name = param_name)
+  if (any(!is.finite(value)) || any(value <= 0)) {
+    stop(sprintf("`%s` must resolve to positive value(s).", param_name), call. = FALSE)
+  }
+  value
+}
+
 ## Sanity-check a non-negative parameter (scalar or function) by sampling it on
 ## `grid` and confirming every resolved value is finite and >= 0. Unlike
 ## check_positive_on_grid this allows the boundary value zero (relevant for

--- a/R/offspring_function_funeral.R
+++ b/R/offspring_function_funeral.R
@@ -31,8 +31,11 @@
 #' @param p_unsafe_funeral_hosp_genPop Numeric between 0 and 1. Probability that a **hospital** death of a genPop leads
 #'   to an unsafe funeral (may be small but non-zero for completeness).
 #'
-#' @param mn_offspring_funeral Positive numeric. Mean of NB distribution for number
-#'   of offspring at an unsafe funeral.
+#' @param mn_offspring_funeral Positive numeric or function(t). Mean of the NB distribution for the
+#'   number of offspring at an unsafe funeral. May be supplied as a single positive scalar or as a
+#'   function of absolute calendar time (e.g. built with \code{\link{make_time_varying}}); when
+#'   time-varying it is resolved at the parent's absolute death (outcome) time, since the funeral
+#'   occurs then rather than at the parent's infection time.
 #' @param overdisp_offspring_funeral Positive numeric. Negative Binomial size (overdispersion).
 #'
 #' @param Tg_shape_funeral Positive numeric. Shape of Gamma delay distribution
@@ -69,7 +72,7 @@ offspring_function_funeral <- function(
   parent_info,
 
   ## Offspring distribution for unsafe funeral event
-  mn_offspring_funeral = NULL, # mean number of offspring at unsafe funeral
+  mn_offspring_funeral = NULL, # scalar or function(t): mean offspring at unsafe funeral (resolved at parent death time)
   overdisp_offspring_funeral = NULL, # overdispersion of the above number of offspring
 
   ## Timing of funeral infections (delay after outcome)
@@ -134,12 +137,23 @@ offspring_function_funeral <- function(
       stop("If parent is NOT hospitalised, `parent_time_to_hospitalisation` must be NA.", call. = FALSE)
   }
 
-  # Other positive parameters
-  for (nm in c("mn_offspring_funeral", "overdisp_offspring_funeral",
+  # Other positive parameters (scalars). mn_offspring_funeral is handled
+  # separately below because it may be a scalar OR a function(t).
+  for (nm in c("overdisp_offspring_funeral",
                "Tg_shape_funeral", "Tg_rate_funeral")) {
     val <- get(nm, inherits = FALSE)
     if (is.null(val) || !is.numeric(val) || length(val) != 1L || is.na(val) || val <= 0)
       stop(sprintf("`%s` must be a single positive numeric value.", nm), call. = FALSE)
+  }
+
+  # mn_offspring_funeral may be a single positive scalar or a function(t) of
+  # absolute calendar time (resolved at the parent's death time, see Step 3).
+  if (!is.function(mn_offspring_funeral)) {
+    if (is.null(mn_offspring_funeral) || !is.numeric(mn_offspring_funeral) ||
+        length(mn_offspring_funeral) != 1L || is.na(mn_offspring_funeral) ||
+        mn_offspring_funeral <= 0)
+      stop("`mn_offspring_funeral` must be a function(t) or a single positive numeric value.",
+           call. = FALSE)
   }
 
   ## Keep safe funeral efficacy as a scalar here. The probability that a funeral
@@ -180,10 +194,16 @@ offspring_function_funeral <- function(
   ## Produce funeral offspring
   #########################################################################################
 
-  # Step 3: Draw raw number of infections from NB at the funeral (assuming initially an unsafe one)
+  # Step 3: Draw raw number of infections from NB at the funeral (assuming initially an unsafe one).
+  #         mn_offspring_funeral may be time-varying. The funeral is a discrete event at the parent's
+  #         death, so resolve transmissibility at the parent's absolute death (outcome) time rather
+  #         than at their infection time.
+  parent_death_time_absolute <- parent_info$time_infection_absolute + parent_time_to_outcome
+  mn_offspring_funeral_t <- resolve_positive_time_varying(
+    mn_offspring_funeral, parent_death_time_absolute, "mn_offspring_funeral")
   num_offspring_raw <- rnbinom(
     n    = 1,
-    mu   = mn_offspring_funeral,
+    mu   = mn_offspring_funeral_t,
     size = overdisp_offspring_funeral
   )
 

--- a/R/offspring_function_genPop.R
+++ b/R/offspring_function_genPop.R
@@ -19,8 +19,11 @@
 #' supplied for backwards compatibility.
 #'
 #' @param parent_info One-row data.frame/list containing parent infection, hospitalisation and outcome times.
-#' @param mn_offspring_genPop Positive numeric. Mean of the Negative Binomial offspring distribution
-#'   for genPop parents (\code{rnbinom(mu = ..., size = ...)}).
+#' @param mn_offspring_genPop Positive numeric or function(t). Mean of the Negative Binomial offspring
+#'   distribution for genPop parents (\code{rnbinom(mu = ..., size = ...)}). May be supplied as a single
+#'   positive scalar or as a function of absolute calendar time (e.g. built with
+#'   \code{\link{make_time_varying}}); when time-varying it is resolved at the parent's absolute
+#'   infection time.
 #' @param overdisp_offspring_genPop Positive numeric. Negative Binomial \code{size} (overdispersion)
 #'   for genPop parents.
 #' @param Tg_shape_genPop Positive numeric. Shape of the Gamma generation-time distribution
@@ -71,7 +74,7 @@ offspring_function_genPop <- function(
   parent_info,
 
   ## Parameters of the offspring and generation time distributions for general population (genPop)
-  mn_offspring_genPop = NULL,               # mean of the offspring distribution for general population
+  mn_offspring_genPop = NULL,               # scalar or function(t): mean offspring distribution for genPop (resolved at parent infection time)
   overdisp_offspring_genPop = NULL,         # overdispersion of the offspring distribution for general population
   Tg_shape_genPop = NULL,                   # gamma shape parameter for Tg distribution for general population
   Tg_rate_genPop = NULL,                    # gamma rate parameter for Tg distribution for general population
@@ -113,6 +116,17 @@ offspring_function_genPop <- function(
   validate_probability_scalar <- function(param, param_name) {
     if (!is.numeric(param) || length(param) != 1L || is.na(param) || param < 0 || param > 1) {
       stop(sprintf("`%s` must be a single numeric in [0, 1].", param_name),
+           call. = FALSE)
+    }
+    invisible(NULL)
+  }
+
+  validate_positive_or_time_varying <- function(param, param_name) {
+    if (is.function(param)) {
+      return(invisible(NULL))
+    }
+    if (is.null(param) || !is.numeric(param) || length(param) != 1L || is.na(param) || param <= 0) {
+      stop(sprintf("`%s` must be a function(t) or a single positive numeric value.", param_name),
            call. = FALSE)
     }
     invisible(NULL)
@@ -196,13 +210,15 @@ offspring_function_genPop <- function(
     }
   }
 
-  ## Parameter checks (positivity / bounds)
-  for (nm in c("mn_offspring_genPop", "overdisp_offspring_genPop", "Tg_shape_genPop", "Tg_rate_genPop")) {
+  ## Parameter checks (positivity / bounds). mn_offspring_genPop is handled
+  ## separately because it may be a scalar OR a function(t); the others are scalars.
+  for (nm in c("overdisp_offspring_genPop", "Tg_shape_genPop", "Tg_rate_genPop")) {
     val <- get(nm, inherits = FALSE)
     if (is.null(val) || length(val) != 1L || !is.numeric(val) || is.na(val) || val <= 0) {
       stop(sprintf("`%s` must be a single positive numeric value.", nm), call. = FALSE)
     }
   }
+  validate_positive_or_time_varying(mn_offspring_genPop, "mn_offspring_genPop")
   for (nm in c("prob_hcw_cond_genPop_comm", "prob_hcw_cond_genPop_hospital")) {
     val <- get(nm, inherits = FALSE)
     if (is.null(val) || length(val) != 1L || !is.numeric(val) || is.na(val) || val < 0 || val > 1) {
@@ -222,8 +238,12 @@ offspring_function_genPop <- function(
   ## Generating offspring, offspring infection times, offspring infection locations & offspring classes
   ########################################################################################################
 
-  # Step 1: Draw from offspring distribution to produce raw number of offspring
-  num_offspring_raw <- rnbinom(n = 1, mu = mn_offspring_genPop, size = overdisp_offspring_genPop)
+  # Step 1: Draw from offspring distribution to produce raw number of offspring.
+  #         mn_offspring_genPop may be time-varying; resolve it once at the parent's
+  #         absolute infection time so the whole brood shares the parent's clock.
+  mn_offspring_genPop_t <- resolve_positive_time_varying(
+    mn_offspring_genPop, parent_time_infection_absolute, "mn_offspring_genPop")
+  num_offspring_raw <- rnbinom(n = 1, mu = mn_offspring_genPop_t, size = overdisp_offspring_genPop)
 
   if (num_offspring_raw == 0L) {
     return(empty_offspring_dataframe())

--- a/R/offspring_function_hcw.R
+++ b/R/offspring_function_hcw.R
@@ -27,8 +27,11 @@
 #' ETU efficacy.
 #'
 #' @param parent_info One-row data.frame/list containing parent infection, hospitalisation and outcome times.
-#' @param mn_offspring_hcw Positive numeric. Mean of the Negative Binomial offspring distribution
-#'   for HCW parents (\code{rnbinom(mu = ..., size = ...)}).
+#' @param mn_offspring_hcw Positive numeric or function(t). Mean of the Negative Binomial offspring
+#'   distribution for HCW parents (\code{rnbinom(mu = ..., size = ...)}). May be supplied as a single
+#'   positive scalar or as a function of absolute calendar time (e.g. built with
+#'   \code{\link{make_time_varying}}); when time-varying it is resolved at the parent's absolute
+#'   infection time.
 #' @param overdisp_offspring_hcw Positive numeric. Negative Binomial \code{size} (overdispersion)
 #'   for HCW parents.
 #' @param Tg_shape_hcw Positive numeric. Shape of the Gamma generation-time distribution
@@ -83,7 +86,7 @@ offspring_function_hcw <- function(
   parent_info,
 
   ## Parameters of the offspring and generation time distributions for HCWs
-  mn_offspring_hcw = NULL,                  # mean of the offspring distribution for HCWs
+  mn_offspring_hcw = NULL,                  # scalar or function(t): mean offspring distribution for HCWs (resolved at parent infection time)
   overdisp_offspring_hcw = NULL,            # overdispersion of the offspring distribution for HCWs
   Tg_shape_hcw = NULL,                      # gamma shape parameter for Tg distribution for HCWs
   Tg_rate_hcw = NULL,                       # gamma rate parameter for Tg distribution for HCWs
@@ -127,6 +130,17 @@ offspring_function_hcw <- function(
   validate_probability_scalar <- function(param, param_name) {
     if (!is.numeric(param) || length(param) != 1L || is.na(param) || param < 0 || param > 1) {
       stop(sprintf("`%s` must be a single numeric in [0, 1].", param_name),
+           call. = FALSE)
+    }
+    invisible(NULL)
+  }
+
+  validate_positive_or_time_varying <- function(param, param_name) {
+    if (is.function(param)) {
+      return(invisible(NULL))
+    }
+    if (is.null(param) || !is.numeric(param) || length(param) != 1L || is.na(param) || param <= 0) {
+      stop(sprintf("`%s` must be a function(t) or a single positive numeric value.", param_name),
            call. = FALSE)
     }
     invisible(NULL)
@@ -210,13 +224,15 @@ offspring_function_hcw <- function(
     }
   }
 
-  ## Parameter checks (positivity / bounds)
-  for (nm in c("mn_offspring_hcw", "overdisp_offspring_hcw", "Tg_shape_hcw", "Tg_rate_hcw")) {
+  ## Parameter checks (positivity / bounds). mn_offspring_hcw is handled separately
+  ## because it may be a scalar OR a function(t); the others are scalars.
+  for (nm in c("overdisp_offspring_hcw", "Tg_shape_hcw", "Tg_rate_hcw")) {
     val <- get(nm, inherits = FALSE)
     if (is.null(val) || length(val) != 1L || !is.numeric(val) || is.na(val) || val <= 0) {
       stop(sprintf("`%s` must be a single positive numeric value.", nm), call. = FALSE)
     }
   }
+  validate_positive_or_time_varying(mn_offspring_hcw, "mn_offspring_hcw")
   for (nm in c("prob_hospital_cond_hcw_preAdm", "prob_hcw_cond_hcw_comm", "prob_hcw_cond_hcw_hospital")) {
     val <- get(nm, inherits = FALSE)
     if (is.null(val) || length(val) != 1L || !is.numeric(val) || is.na(val) || val < 0 || val > 1) {
@@ -236,8 +252,12 @@ offspring_function_hcw <- function(
   ## Generating offspring, offspring infection times, offspring infection locations & offspring classes
   ########################################################################################################
 
-  # Step 1: Draw from offspring distribution to produce raw number of offspring
-  num_offspring_raw <- rnbinom(n = 1, mu = mn_offspring_hcw, size = overdisp_offspring_hcw)
+  # Step 1: Draw from offspring distribution to produce raw number of offspring.
+  #         mn_offspring_hcw may be time-varying; resolve it once at the parent's
+  #         absolute infection time so the whole brood shares the parent's clock.
+  mn_offspring_hcw_t <- resolve_positive_time_varying(
+    mn_offspring_hcw, parent_time_infection_absolute, "mn_offspring_hcw")
+  num_offspring_raw <- rnbinom(n = 1, mu = mn_offspring_hcw_t, size = overdisp_offspring_hcw)
 
   if (num_offspring_raw == 0L) {
     return(empty_offspring_dataframe())

--- a/man/branching_process_main.Rd
+++ b/man/branching_process_main.Rd
@@ -71,8 +71,8 @@ Top-level entry point for fiber's filovirus branching-process model.
 Iteratively generates offspring (community, hospital, and funeral
 transmission) from active cases until the outbreak ends or the configured
 final-size cap is reached. Time-varying scenario inputs (probabilities,
-delay factors, IPC / ETU coverage) can be passed as scalars or functions
-of time produced by \code{\link[=make_time_varying]{make_time_varying()}}.
+delay factors, IPC / ETU coverage, and mean-offspring transmissibility) can
+be passed as scalars or functions of time produced by \code{\link[=make_time_varying]{make_time_varying()}}.
 }
 \details{
 Per-argument documentation is pending; see the inline comments in

--- a/man/offspring_function_funeral.Rd
+++ b/man/offspring_function_funeral.Rd
@@ -23,8 +23,11 @@ offspring_function_funeral(
 )
 }
 \arguments{
-\item{mn_offspring_funeral}{Positive numeric. Mean of NB distribution for number
-of offspring at an unsafe funeral.}
+\item{mn_offspring_funeral}{Positive numeric or function(t). Mean of the NB distribution for the
+number of offspring at an unsafe funeral. May be supplied as a single positive scalar or as a
+function of absolute calendar time (e.g. built with \code{\link{make_time_varying}}); when
+time-varying it is resolved at the parent's absolute death (outcome) time, since the funeral
+occurs then rather than at the parent's infection time.}
 
 \item{overdisp_offspring_funeral}{Positive numeric. Negative Binomial size (overdispersion).}
 

--- a/man/offspring_function_genPop.Rd
+++ b/man/offspring_function_genPop.Rd
@@ -29,8 +29,11 @@ offspring_function_genPop(
 \arguments{
 \item{parent_info}{One-row data.frame/list containing parent infection, hospitalisation and outcome times.}
 
-\item{mn_offspring_genPop}{Positive numeric. Mean of the Negative Binomial offspring distribution
-for genPop parents (\code{rnbinom(mu = ..., size = ...)}).}
+\item{mn_offspring_genPop}{Positive numeric or function(t). Mean of the Negative Binomial offspring
+distribution for genPop parents (\code{rnbinom(mu = ..., size = ...)}). May be supplied as a single
+positive scalar or as a function of absolute calendar time (e.g. built with
+\code{\link{make_time_varying}}); when time-varying it is resolved at the parent's absolute
+infection time.}
 
 \item{overdisp_offspring_genPop}{Positive numeric. Negative Binomial \code{size} (overdispersion)
 for genPop parents.}

--- a/man/offspring_function_hcw.Rd
+++ b/man/offspring_function_hcw.Rd
@@ -30,8 +30,11 @@ offspring_function_hcw(
 \arguments{
 \item{parent_info}{One-row data.frame/list containing parent infection, hospitalisation and outcome times.}
 
-\item{mn_offspring_hcw}{Positive numeric. Mean of the Negative Binomial offspring distribution
-for HCW parents (\code{rnbinom(mu = ..., size = ...)}).}
+\item{mn_offspring_hcw}{Positive numeric or function(t). Mean of the Negative Binomial offspring
+distribution for HCW parents (\code{rnbinom(mu = ..., size = ...)}). May be supplied as a single
+positive scalar or as a function of absolute calendar time (e.g. built with
+\code{\link{make_time_varying}}); when time-varying it is resolved at the parent's absolute
+infection time.}
 
 \item{overdisp_offspring_hcw}{Positive numeric. Negative Binomial \code{size} (overdispersion)
 for HCW parents.}

--- a/tests/testthat/test-time_varying_transmissibility.R
+++ b/tests/testthat/test-time_varying_transmissibility.R
@@ -1,0 +1,286 @@
+## Tests for time-varying mean-offspring transmissibility:
+##   mn_offspring_genPop, mn_offspring_hcw, mn_offspring_funeral.
+##
+## These may be supplied as a single positive scalar (back-compatible) or as a
+## function(t) of absolute calendar time. genPop/HCW are resolved at the
+## parent's infection time; funeral is resolved at the parent's death time.
+
+## --- helpers --------------------------------------------------------------
+
+## A parent_info row with the columns the offspring functions read. Defaults to
+## a non-hospitalised genPop case that dies (so funeral transmission can fire and
+## genPop community offspring are not subject to hospital thinning).
+make_parent_info <- function(time_infection_absolute = 0,
+                             time_outcome_relative   = 12,
+                             class                   = "genPop",
+                             hospitalised            = FALSE,
+                             outcome                 = TRUE,
+                             funeral_safety          = "unsafe") {
+  data.frame(
+    id                             = 1L,
+    class                          = class,
+    infection_location             = "community",
+    parent                         = NA_integer_,
+    generation                     = 1L,
+    time_infection_relative        = 0,
+    time_infection_absolute        = time_infection_absolute,
+    incubation_period              = 5,
+    symptomatic                    = TRUE,
+    time_symptom_onset_relative    = 5,
+    time_symptom_onset_absolute    = time_infection_absolute + 5,
+    hospitalisation                = hospitalised,
+    time_hospitalisation_relative  = if (hospitalised) 3 else NA_real_,
+    time_hospitalisation_absolute  = if (hospitalised) time_infection_absolute + 3 else NA_real_,
+    outcome                        = outcome,
+    outcome_location               = "community",
+    time_outcome_relative          = time_outcome_relative,
+    time_outcome_absolute          = time_infection_absolute + time_outcome_relative,
+    funeral_safety                 = funeral_safety,
+    n_offspring                    = NA_integer_,
+    offspring_generated            = FALSE,
+    stringsAsFactors               = FALSE
+  )
+}
+
+## Mean realised offspring count over `reps` independent calls (different seeds).
+mean_offspring_genPop <- function(reps, parent, mn, base_seed = 0) {
+  counts <- vapply(seq_len(reps), function(i) {
+    set.seed(base_seed + i)
+    nrow(offspring_function_genPop(
+      parent_info                   = parent,
+      mn_offspring_genPop           = mn,
+      overdisp_offspring_genPop     = 5,
+      Tg_shape_genPop               = 2,
+      Tg_rate_genPop                = 0.15,
+      hospital_quarantine_efficacy  = 0.5,
+      ppe_efficacy_hcw              = 0.5,
+      prob_hcw_cond_genPop_comm     = 0,
+      prob_hcw_cond_genPop_hospital = 0.3
+    ))
+  }, numeric(1))
+  mean(counts)
+}
+
+mean_offspring_funeral <- function(reps, parent, mn, base_seed = 0) {
+  counts <- vapply(seq_len(reps), function(i) {
+    set.seed(base_seed + i)
+    nrow(offspring_function_funeral(
+      parent_info                  = parent,
+      mn_offspring_funeral         = mn,
+      overdisp_offspring_funeral   = 5,
+      Tg_shape_funeral             = 10,
+      Tg_rate_funeral              = 5,
+      safe_funeral_efficacy        = 1.0,
+      prob_hcw_cond_funeral_hcw    = 0,
+      prob_hcw_cond_funeral_genPop = 0
+    ))
+  }, numeric(1))
+  mean(counts)
+}
+
+## A full, valid branching_process_main() argument set (scalars by default).
+fixed_inc   <- function(n) rep(5, n)
+fixed_hosp  <- function(n) rep(3, n)
+fixed_death <- function(n) rep(7, n)
+fixed_recov <- function(n) rep(10, n)
+
+bpm_args <- function(...) {
+  defaults <- list(
+    mn_offspring_genPop           = 1.5,
+    overdisp_offspring_genPop     = 0.5,
+    Tg_shape_genPop               = 2,
+    Tg_rate_genPop                = 0.15,
+    mn_offspring_hcw              = 1.5,
+    overdisp_offspring_hcw        = 0.5,
+    Tg_shape_hcw                  = 2,
+    Tg_rate_hcw                   = 0.15,
+    mn_offspring_funeral          = 1.5,
+    overdisp_offspring_funeral    = 0.5,
+    Tg_shape_funeral              = 10,
+    Tg_rate_funeral               = 5,
+    incubation_period             = fixed_inc,
+    onset_to_hospitalisation      = fixed_hosp,
+    onset_to_death                = fixed_death,
+    onset_to_recovery             = fixed_recov,
+    hospitalisation_to_death      = fixed_death,
+    hospitalisation_to_recovery   = fixed_recov,
+    prob_symptomatic              = 0.9,
+    prob_hospitalised_hcw         = 0.5,
+    prob_hospitalised_genPop      = 0.5,
+    prob_death_comm               = 0.5,
+    prob_death_hosp               = 0.3,
+    prob_hcw_cond_genPop_comm     = 0.01,
+    prob_hcw_cond_genPop_hospital = 0.3,
+    prob_hcw_cond_hcw_comm        = 0.01,
+    prob_hcw_cond_hcw_hospital    = 0.3,
+    prob_hospital_cond_hcw_preAdm = 0.5,
+    ppe_efficacy_hcw              = 0.5,
+    hospital_quarantine_efficacy  = 0.5,
+    p_unsafe_funeral_comm_hcw     = 0.5,
+    p_unsafe_funeral_hosp_hcw     = 0.2,
+    p_unsafe_funeral_comm_genPop  = 0.5,
+    p_unsafe_funeral_hosp_genPop  = 0.2,
+    safe_funeral_efficacy         = 1.0,
+    prob_hcw_cond_funeral_hcw     = 0.05,
+    prob_hcw_cond_funeral_genPop  = 0.05,
+    population                    = 5000,
+    hcw_per_capita                = 0.02,
+    check_final_size              = 200,
+    seeding_cases                 = 3,
+    seed                          = 1L
+  )
+  utils::modifyList(defaults, list(...))
+}
+
+## --- resolve_positive_time_varying unit tests -----------------------------
+
+test_that("resolve_positive_time_varying handles scalars and functions", {
+  expect_equal(resolve_positive_time_varying(5, 10, "x"), 5)
+  expect_equal(resolve_positive_time_varying(function(t) t + 1, 4, "x"), 5)
+  expect_equal(resolve_positive_time_varying(function(t) rep(2, length(t)), c(0, 5, 9), "x"),
+               c(2, 2, 2))
+})
+
+test_that("resolve_positive_time_varying rejects non-positive values", {
+  expect_error(resolve_positive_time_varying(0, 0, "x"), "positive")
+  expect_error(resolve_positive_time_varying(-1, 0, "x"), "positive")
+  expect_error(resolve_positive_time_varying(function(t) -1, 5, "x"), "positive")
+})
+
+## --- Scalar back-compat & constant-function equivalence -------------------
+
+test_that("offspring_function_genPop accepts a scalar mn (back-compatible)", {
+  set.seed(1)
+  res <- offspring_function_genPop(
+    parent_info                   = make_parent_info(),
+    mn_offspring_genPop           = 8,
+    overdisp_offspring_genPop     = 5,
+    Tg_shape_genPop               = 2,
+    Tg_rate_genPop                = 0.15,
+    hospital_quarantine_efficacy  = 0.5,
+    ppe_efficacy_hcw              = 0.5,
+    prob_hcw_cond_genPop_comm     = 0,
+    prob_hcw_cond_genPop_hospital = 0.3
+  )
+  expect_s3_class(res, "data.frame")
+  expect_true(all(c("infection_location", "time_infection_relative", "class") %in% names(res)))
+})
+
+test_that("a constant function(t) reproduces the scalar exactly (genPop)", {
+  parent <- make_parent_info()
+
+  set.seed(123)
+  res_scalar <- offspring_function_genPop(
+    parent_info                   = parent,
+    mn_offspring_genPop           = 8,
+    overdisp_offspring_genPop     = 5,
+    Tg_shape_genPop               = 2,
+    Tg_rate_genPop                = 0.15,
+    hospital_quarantine_efficacy  = 0.5,
+    ppe_efficacy_hcw              = 0.5,
+    prob_hcw_cond_genPop_comm     = 0,
+    prob_hcw_cond_genPop_hospital = 0.3
+  )
+
+  set.seed(123)
+  res_fn <- offspring_function_genPop(
+    parent_info                   = parent,
+    mn_offspring_genPop           = function(t) 8,
+    overdisp_offspring_genPop     = 5,
+    Tg_shape_genPop               = 2,
+    Tg_rate_genPop                = 0.15,
+    hospital_quarantine_efficacy  = 0.5,
+    ppe_efficacy_hcw              = 0.5,
+    prob_hcw_cond_genPop_comm     = 0,
+    prob_hcw_cond_genPop_hospital = 0.3
+  )
+
+  expect_identical(res_scalar$time_infection_relative, res_fn$time_infection_relative)
+  expect_identical(res_scalar$class, res_fn$class)
+})
+
+## --- Time-variation actually changes offspring counts ---------------------
+
+test_that("time-varying mn_offspring_genPop is keyed to the parent's infection time", {
+  ## High transmissibility early (t < 100), low late.
+  mn_fn <- function(t) ifelse(t < 100, 40, 2)
+
+  parent_early <- make_parent_info(time_infection_absolute = 0)    # mn(0)   = 40
+  parent_late  <- make_parent_info(time_infection_absolute = 200)  # mn(200) = 2
+
+  mean_early <- mean_offspring_genPop(reps = 60, parent = parent_early, mn = mn_fn)
+  mean_late  <- mean_offspring_genPop(reps = 60, parent = parent_late,  mn = mn_fn)
+
+  expect_gt(mean_early, 25)   # near 40
+  expect_lt(mean_late,  10)   # near 2
+  expect_gt(mean_early, mean_late)
+})
+
+test_that("time-varying mn_offspring_funeral is keyed to the parent's DEATH time", {
+  ## Low early (t < 100), high late. Both parents are infected at t = 0, so if
+  ## the funeral mean were (wrongly) keyed to infection time both would be low.
+  ## Keyed to death time, the late-dying parent should generate many more.
+  mn_fn <- function(t) ifelse(t < 100, 2, 40)
+
+  parent_dies_late  <- make_parent_info(time_infection_absolute = 0,
+                                        time_outcome_relative = 150)  # death @150 -> 40
+  parent_dies_early <- make_parent_info(time_infection_absolute = 0,
+                                        time_outcome_relative = 10)   # death @10  -> 2
+
+  mean_late  <- mean_offspring_funeral(reps = 60, parent = parent_dies_late,  mn = mn_fn)
+  mean_early <- mean_offspring_funeral(reps = 60, parent = parent_dies_early, mn = mn_fn)
+
+  expect_gt(mean_late, 25)   # near 40, proving death-time anchoring
+  expect_lt(mean_early, 10)  # near 2
+  expect_gt(mean_late, mean_early)
+})
+
+## --- Validation -----------------------------------------------------------
+
+test_that("offspring functions reject a non-positive scalar mn", {
+  expect_error(
+    offspring_function_genPop(
+      parent_info                   = make_parent_info(),
+      mn_offspring_genPop           = -1,
+      overdisp_offspring_genPop     = 5,
+      Tg_shape_genPop               = 2,
+      Tg_rate_genPop                = 0.15,
+      hospital_quarantine_efficacy  = 0.5,
+      ppe_efficacy_hcw              = 0.5,
+      prob_hcw_cond_genPop_comm     = 0,
+      prob_hcw_cond_genPop_hospital = 0.3
+    ),
+    "mn_offspring_genPop"
+  )
+})
+
+test_that("branching_process_main rejects a mn curve that dips to <= 0", {
+  bad <- make_time_varying(c(0, 30, 60), c(2, 1, -0.5))
+  expect_error(
+    do.call(branching_process_main, bpm_args(mn_offspring_genPop = bad)),
+    "mn_offspring_genPop.*positive"
+  )
+})
+
+## --- End-to-end integration ----------------------------------------------
+
+test_that("branching_process_main runs with time-varying mn_offspring_*", {
+  args <- bpm_args(
+    mn_offspring_genPop  = make_time_varying(c(0, 60, 120), c(2.0, 1.2, 0.6)),
+    mn_offspring_hcw     = function(t) 1.5,
+    mn_offspring_funeral = make_time_varying(c(0, 60), c(2.0, 0.5))
+  )
+  out <- do.call(branching_process_main, args)
+  expect_true(is.list(out))
+  expect_true(nrow(out$tdf) > 0)
+})
+
+test_that("a constant function reproduces the scalar run exactly (full sim)", {
+  out_scalar <- do.call(branching_process_main, bpm_args(mn_offspring_genPop = 1.5))
+  out_fn     <- do.call(branching_process_main, bpm_args(mn_offspring_genPop = function(t) 1.5))
+  ## Same seed + same resolved mean + no extra RNG draws => identical tree.
+  expect_identical(out_scalar$tdf$time_infection_absolute,
+                   out_fn$tdf$time_infection_absolute)
+  expect_identical(out_scalar$tdf$class, out_fn$tdf$class)
+  expect_identical(nrow(out_scalar$tdf), nrow(out_fn$tdf))
+})


### PR DESCRIPTION
## Summary

Allows the three mean-offspring (transmissibility) parameters — `mn_offspring_genPop`, `mn_offspring_hcw`, `mn_offspring_funeral` — to be supplied as a `function(t)` of absolute calendar time (e.g. via `make_time_varying()`) in addition to a scalar, matching the existing time-varying inputs (`prob_hospitalised_*`, `hospitalisation_delay_factor`, IPC/ETU coverage, …).

## Behaviour / design

- The mean is resolved to a single value per parent immediately before the NB draw:
  - **genPop / HCW** at the **parent's infection time**
  - **funeral** at the **parent's death (outcome) time**, since the funeral occurs then
- Scalars are fully backward-compatible. A constant `function(t)` reproduces the equivalent scalar run **bit-for-bit** under a fixed seed (no extra RNG draws).
- `compute_reproduction_number()` is unchanged — it reads the realised tree. Because `R_case(t)` is indexed by the infector's infection time, the input genPop curve and the realised `R_case(t)` line up (modulo MCM thinning), which makes a handy built-in sanity check.

## Changes

- **`R/helper_functions.R`** — new internal `resolve_positive_time_varying()`: a scalar-or-`function(t)` resolver with a strict positivity assertion.
- **`R/offspring_function_{genPop,hcw,funeral}.R`** — validate `mn_offspring_*` as function-or-positive-scalar, then resolve it at the appropriate clock before the `rnbinom()` draw.
- **`R/branching_process_main.R`** — build the upfront sanity grid from **all** time-varying inputs (also closing a pre-existing gap where `hospitalisation_delay_factor` / `obv_pep_dpc` breakpoints weren't sampled) and add positivity checks for the three means across the simulation horizon.
- **Docs** — `man/*.Rd`, `CLAUDE.md`.

## Tests

New `tests/testthat/test-time_varying_transmissibility.R`:

- scalar back-compat
- constant `function(t)` ≡ scalar under a fixed seed (offspring-function and full-sim levels)
- genPop keyed to the parent's **infection** time; funeral keyed to the parent's **death** time
- validation errors (non-positive scalar) and upfront rejection of a curve that dips ≤ 0
- end-to-end run with time-varying `mn_offspring_*`

> **Verification note:** this sandbox had no CRAN access, so `testthat` / `roxygen2` couldn't be installed. Behaviour was verified with a base-R harness that sources the package and exercises every case (15/15 passed), and the `man/*.Rd` files were updated by hand. Please run `devtools::document()` + `devtools::test()` locally to regenerate the docs canonically and confirm the suite.

https://claude.ai/code/session_01ShHyZxC1SYaRonD1TSqogU

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShHyZxC1SYaRonD1TSqogU)_