### PR TITLE
Fix stale comment on obv_pep_efficacy_args default

### DIFF
--- a/R/branching_process_main.R
+++ b/R/branching_process_main.R
@@ -240,7 +240,7 @@ branching_process_main <- function(
   obv_pep_dpc = 1,                           # scalar/function(t): days post challenge/exposure to first dose (mean DPC when a shape is set)
   obv_pep_dpc_shape = NULL,                  # NULL = deterministic DPC; positive scalar = per-recipient Gamma(mean = obv_pep_dpc(t), shape) draw
   obv_pep_efficacy = NULL,                   # NULL/function(dpc)/scalar: efficacy; NULL uses obv_pep_efficacy_from_dpc()
-  obv_pep_efficacy_args = NULL,              # NULL or named list of overrides for obv_pep_efficacy_from_dpc() (E0/d50/k/dpc_zero/max_dpc); used only when obv_pep_efficacy = NULL
+  obv_pep_efficacy_args = NULL,              # NULL or named list of overrides for obv_pep_efficacy_from_dpc() (shape/E0/d50/k/dpc_zero/max_dpc); used when obv_pep_efficacy is NULL or a scalar (errors if a function)
   obv_pep_target_class = "HCW",              # character vector: offspring classes eligible for OBV PEP
   obv_pep_target_locations = "hospital",     # character vector: exposure settings eligible for OBV PEP
 


### PR DESCRIPTION
## What

Corrects the inline comment on the `obv_pep_efficacy_args` default argument in `R/branching_process_main.R`.

## Why

The comment claimed the argument is **"used only when `obv_pep_efficacy = NULL`"**, which is inaccurate. Looking at the actual resolution logic in `resolve_obv_efficacy()` (`R/helper_functions.R`):

- `obv_pep_efficacy = NULL` → built-in curve; `obv_pep_efficacy_args` used directly.
- `obv_pep_efficacy = <scalar>` → built-in curve; `obv_pep_efficacy_args` **also used**, with `E0 = <scalar>` prepended.
- `obv_pep_efficacy = function(dpc)` → `validate_obv_efficacy_args()` **errors** (the args are not silently ignored).

So the args apply whenever the built-in curve is selected — i.e. when `obv_pep_efficacy` is NULL **or a scalar** — which is exactly what both the Roxygen `@param` (lines 115–120) and the validation-block comment (lines 413–417) already state. The line-243 comment was the lone outlier.

This means usage like the following is valid and behaves as expected:

```r
branching_process_main(..., obv_pep_efficacy = 0.8,
                       obv_pep_efficacy_args = list(shape = "logistic", d50 = 4))
# -> logistic decay with peak (E0) = 0.8
```

## Change

```diff
- obv_pep_efficacy_args = NULL,  # ... (E0/d50/k/dpc_zero/max_dpc); used only when obv_pep_efficacy = NULL
+ obv_pep_efficacy_args = NULL,  # ... (shape/E0/d50/k/dpc_zero/max_dpc); used when obv_pep_efficacy is NULL or a scalar (errors if a function)
```

Also adds the missing `shape` to the listed override names. Comment-only change — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNp71vsfqAQFBwx4tXQiyM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNp71vsfqAQFBwx4tXQiyM)_